### PR TITLE
fix: missing libdrm dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ libinput = dependency('libinput')
 xxhash = dependency('libxxhash')
 lua = dependency('luajit')
 xcb = dependency('xcb')
+libdrm_header = dependency('libdrm').partial_dependency(compile_args: true, includes: true)
 libm = cc.find_library('m', required : true)
 libdl = cc.find_library('dl', required : true)
 
@@ -50,6 +51,7 @@ all_deps = [
   xxhash,
   lua,
   xcb,
+  libdrm_header,
   libm,
   libdl,
 ]


### PR DESCRIPTION
The `meson.build` is missing a dependency which causes a compilation error to happened.

```
../src/input/cursor.c:27:10: fatal error: drm_fourcc.h: No such file or directory
   27 | #include <drm_fourcc.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
```

This PR should fix the compilation error by adding a partial libdrm dependency, which follows the [`meson.build`](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/9dbf5b9f6b3ed486f88605ae0c93e191e528e42d/examples/meson.build#L3) in the wlroots example folder.