### PR TITLE
fix: replace hardcoded usr dir with options

### DIFF
--- a/cwctl/meson.build
+++ b/cwctl/meson.build
@@ -29,5 +29,5 @@ executable(
   srcs,
   include_directories : cwc_inc,
   install: true,
-  install_dir: '/usr/bin',
+  install_dir: get_option('bindir'),
 )

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('cwcwm', 'c', 'cpp', default_options: ['c_std=gnu23,gnu17,gnu11','b_ndebug=if-release'])
 
-cwc_datadir = '/usr/share/cwc'
+cwc_datadir = get_option('datadir') / 'cwc'
 add_project_arguments([
   '-DWLR_USE_UNSTABLE',
   '-DHHMAP_AUTOMATIC_REHASH',
@@ -74,7 +74,7 @@ endif
 # install script
 install_subdir('lib', install_dir: cwc_datadir)
 install_subdir('defconfig', install_dir: cwc_datadir)
-install_subdir('doc', install_dir: '/usr/share/doc/cwc')
-install_subdir('include/cwc', install_dir: '/usr/include')
-install_data('cwc.desktop', install_dir: '/usr/share/wayland-sessions')
-install_data('cwc-portals.conf', install_dir: '/usr/share/xdg-desktop-portal')
+install_subdir('doc', install_dir: get_option('datadir') / 'doc/cwc')
+install_subdir('include/cwc', install_dir: get_option('includedir'))
+install_data('cwc.desktop', install_dir: get_option('datadir') / 'wayland-sessions')
+install_data('cwc-portals.conf', install_dir: get_option('datadir') / 'xdg-desktop-portal')

--- a/src/meson.build
+++ b/src/meson.build
@@ -72,7 +72,7 @@ executable(
   'cwc',
   srcs,
   install: true,
-  install_dir: '/usr/bin',
+  install_dir: get_option('bindir'),
   dependencies: all_deps,
   include_directories : cwc_inc,
   link_args : ['-Wl,--export-dynamic'],


### PR DESCRIPTION
Replace hardcoded prefix directory with options via `get_option`.