### PR TITLE
cwctl: reload

### DIFF
--- a/cwctl/main.c
+++ b/cwctl/main.c
@@ -45,6 +45,7 @@ static char *help_txt =
     "  screen    Get all screen information\n"
     "  binds     Get all active keybinds information\n"
     "  plugin    Get all loaded plugin information\n"
+    "  reload    Reload currently running cwc session\n"
     "  help      Help about any command/subcommand\n"
     "  version   Print cwc version\n"
     "\n"
@@ -128,6 +129,8 @@ static int object_command(int argc, char **argv)
         repl((char *)_cwctl_script_plugin_lua);
     } else if (strcmp(command, "binds") == 0) {
         repl((char *)_cwctl_script_binds_lua);
+    } else if (strcmp(command, "reload") == 0) {
+        repl("return cwc.reload()");
     } else if (strcmp(command, "version") == 0) {
         repl("return cwc.get_version()");
     } else {


### PR DESCRIPTION
`cwctl reload` 
Literally just runs `cwc.reload()`. Can make newcomers FAR less confused ~~and also makes it less annoying when I mess up my rc.lua and am left unable to reload using shortcuts~~