### PR TITLE
luapi!: add declarative config and remove some imperative config function

### DIFF
--- a/defconfig/conf.lua
+++ b/defconfig/conf.lua
@@ -2,9 +2,12 @@ local gears = require("gears")
 local enum = require("cuteful.enum")
 
 local conf = {
+    -- misc --
+    tasklist_show_all                  = false,
+
     -- pointer config --
     cursor_size                        = 20,
-    cursor_inactive_timeout            = 5,
+    cursor_inactive_timeout            = 5000,
     cursor_edge_threshold              = 32,
     cursor_edge_snapping_overlay_color = { 0.1, 0.2, 0.3, 0.05 },
 

--- a/defconfig/conf.lua
+++ b/defconfig/conf.lua
@@ -25,6 +25,7 @@ local conf = {
     border_color_focus                 = gears.color(
         "linear:0,0:0,0:0,#f08e97:0.1,#a7e1a4:0.2,#ffffa7:0.3,#a5c0e1:0.4,#c8a6e1:0.5,#a1d0d4:0.6,#f9b486:0.7,#e1a5d7:0.8,#b4b8e6:0.9,#b4b8e6:1.0,#f8e0b4"),
     border_color_normal                = gears.color("#423e44"),
+    border_color_raised                = gears.color("#d2d6f9"),
 
     -- screen/tag config --
     useless_gaps                       = 3,

--- a/defconfig/conf.lua
+++ b/defconfig/conf.lua
@@ -1,0 +1,30 @@
+local gears = require("gears")
+local enum = require("cuteful.enum")
+
+local conf = {
+    -- pointer config --
+    cursor_size                        = 20,
+    cursor_inactive_timeout            = 5,
+    cursor_edge_threshold              = 32,
+    cursor_edge_snapping_overlay_color = { 0.1, 0.2, 0.3, 0.05 },
+
+    -- keyboard config --
+    repeat_rate                        = 30,
+    repeat_delay                       = 300,
+    -- xkb_variant = "colemak",
+    -- xkb_layout  = "us,de,fr",
+    -- xkb_options = "grp:ctrl_shift_toggle",
+
+    -- client config --
+    default_decoration_mode            = enum.decoration_mode.SERVER_SIDE,
+    border_width                       = 1,
+    border_color_rotation              = 64,
+    border_color_focus                 = gears.color(
+        "linear:0,0:0,0:0,#f08e97:0.1,#a7e1a4:0.2,#ffffa7:0.3,#a5c0e1:0.4,#c8a6e1:0.5,#a1d0d4:0.6,#f9b486:0.7,#e1a5d7:0.8,#b4b8e6:0.9,#b4b8e6:1.0,#f8e0b4"),
+    border_color_normal                = gears.color("#423e44"),
+
+    -- screen/tag config --
+    useless_gaps                       = 3,
+}
+
+return conf

--- a/defconfig/rc.lua
+++ b/defconfig/rc.lua
@@ -24,11 +24,6 @@ end
 -- execute keybind script
 gears.protected_call(require, "keybind")
 
--- plugin config
-if cwc.cwcle then
-    cwc.cwcle.set_border_color_raised(gears.color("#d2d6f9"))
-end
-
 -- use all implementation
 impl.use_all()
 

--- a/defconfig/rc.lua
+++ b/defconfig/rc.lua
@@ -24,8 +24,8 @@ end
 -- execute keybind script
 gears.protected_call(require, "keybind")
 
--- use all implementation
-impl.use_all()
+-- use core implementation
+impl.use_core()
 
 -- input device config
 cwc.connect_signal("input::new", function(dev)

--- a/defconfig/rc.lua
+++ b/defconfig/rc.lua
@@ -46,9 +46,6 @@ cwc.connect_signal("input::new", function(dev)
     end
 end)
 
--- uncategorized
-cwc.tasklist_show_all = false
-
 ------------------------------- SCREEN SETUP ------------------------------------
 cwc.connect_signal("screen::new", function(screen)
     -- screen settings

--- a/defconfig/rc.lua
+++ b/defconfig/rc.lua
@@ -7,9 +7,14 @@ pcall(require, "luarocks.loader")
 local gears = require("gears")
 local enum = require("cuteful.enum")
 local tag = require("cuteful.tag")
+local impl = require("impl")
+local config = require("config")
 
 -- make it local so the `undefined global` lsp error stop yapping on every cwc access
 local cwc = cwc
+
+-- config.init should go first before anything else
+config.init(require("conf"))
 
 -- execute oneshot.lua once, cwc.is_startup() mark that the configuration is loaded for the first time
 if cwc.is_startup() then
@@ -19,39 +24,13 @@ end
 -- execute keybind script
 gears.protected_call(require, "keybind")
 
----------------------------------- CONFIGURATION --------------------------------------
--- A library for declarative configuration and per device configuration will be added later.
--- If you change configuration at runtime some of configuration need to get committed by calling
--- `cwc.commit()``
-
--- pointer config
-cwc.pointer.set_cursor_size(20)
-cwc.pointer.set_inactive_timeout(5)
-cwc.pointer.set_edge_threshold(32)
-cwc.pointer.set_edge_snapping_overlay_color(0.1, 0.2, 0.3, 0.05)
-
--- keyboard config
-cwc.kbd.set_repeat_rate(30)
-cwc.kbd.set_repeat_delay(300)
--- cwc.kbd.xkb_variant = "colemak"
--- cwc.kbd.xkb_layout  = "us,de,fr"
--- cwc.kbd.xkb_options = "grp:ctrl_shift_toggle"
-
--- client config
-cwc.client.default_decoration_mode = enum.decoration_mode.SERVER_SIDE;
-cwc.client.set_border_color_focus(gears.color(
-    "linear:0,0:0,0:0,#f08e97:0.1,#a7e1a4:0.2,#ffffa7:0.3,#a5c0e1:0.4,#c8a6e1:0.5,#a1d0d4:0.6,#f9b486:0.7,#e1a5d7:0.8,#b4b8e6:0.9,#b4b8e6:1.0,#f8e0b4"))
-cwc.client.set_border_color_normal(gears.color("#423e44"))
-cwc.client.set_border_width(1)
-cwc.client.set_border_color_rotation(64)
-
--- screen/tag config
-cwc.screen.set_useless_gaps(3)
-
 -- plugin config
 if cwc.cwcle then
     cwc.cwcle.set_border_color_raised(gears.color("#d2d6f9"))
 end
+
+-- use all implementation
+impl.use_all()
 
 -- input device config
 cwc.connect_signal("input::new", function(dev)

--- a/docs/00-getting-started.md
+++ b/docs/00-getting-started.md
@@ -116,6 +116,37 @@ if cwc.cwcle then
 end
 ```
 
+Or better yet using the declarative config like so.
+Below script is equivalent to the script above.
+
+```lua
+---- ./conf.lua ----
+local gears = require("gears")
+
+local conf = {
+    cursor_size = 24,
+    repeat_rate = 30,
+    border_color_normal = gears.color(gears.color("#423e44"))
+    border_color_raised = gears.color(gears.color("#d2d6f9"))
+}
+
+return conf
+
+---- ./rc.lua ----
+local config = require("config")
+
+-- config.init should go first before anything else
+config.init(require("conf"))
+
+-- rest of script...
+```
+
+Before really opening the wayland session,
+it is better to run `cwc --check` to verify if there any error in the configuration,
+so there is no confusing blank screen.
+
+To switch tty press `ALT + CTRL + Fn` where n is the tty number.
+
 ## Default Keybinding
 
 ### cwc

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -294,10 +294,114 @@ create_type {
 }
 
 create_type {
-    name           = "config",
-    title          = "Config key",
-    project_level  = false,
-    subfield_title = "Type constraints",
+    name            = "config",
+    title           = "Config key",
+    project_level   = false,
+    subfield_title  = "Type constraints",
+    finish_callback = function(item)
+        -- All properties need to have a type. Otherwise they don't render
+        -- properly. Also, because typed properties are kind of the point of
+        -- switching to ldoc in the first place.
+        if (not item.params) or not item.params[1] then
+            print(
+                "WARNING: The " ..
+                item.name .. " property from " .. item.module.name .. " is missing it's type."
+            )
+            return
+        end
+
+        local _, sublist = item:subparam(item.params[1])
+        local type = item:type_of_param(item.params[1])
+
+        -- Force people to use @tparam because it is easier to lint and allows
+        -- multiple types.
+        if (not type) or type == "" then
+            print(
+                "WARNING: Property " .. item.name .. " from " .. item.module.name .. " either " ..
+                " doesn't have a type or uses @param instead of @tparam. @tparam is required" ..
+                " because it allows multi-type and better default value handling."
+            )
+        end
+
+        if type_name_linting[type] then
+            print(
+                "WARNING: Property " .. item.name .. " from " .. item.module.name ..
+                " type is `" .. type .. "`, please use `" .. type_name_linting[type] .. "`."
+            )
+        end
+
+        -- One of the repeated problem we have is the first word of the
+        -- description being removed because it is used as the property name.
+        -- This "rule" might be stupid, but it prevents it from accidentally
+        -- happening again.
+        if item.params[1] ~= item.name:match("[.]?(" .. item.params[1] .. ")$") then
+            print(
+                "WARNING: Property " ..
+                item.name .. " from " .. item.module.name .. " @tparam name" ..
+                " doesn't match the property name. For linting purpose, please fix this."
+            )
+        end
+
+        local def = item:default_of_param(item.params[1])
+
+        -- Check the default value for obvious mistakes.
+        if def then
+            -- Detect the blatant missing quote marks for string. This is important
+            -- to differentiate variables from string literals.
+            if type == "string" and def:sub(1, 1) ~= '"' and def:sub(-1) ~= '"' and not def:find(".") then
+                print(
+                    "WARNING: Property " .. item.name .. " from " .. item.module.name ..
+                    " is a string, but the default value is not quoted."
+                )
+            end
+
+            -- If the default value is `nil`, then the property must be nullable.
+            if def == "nil" and not type:find("nil") then
+                print(
+                    "WARNING: Property " .. item.name .. " from " .. item.module.name ..
+                    " default value is `nil`, but the type doesn't allow it"
+                )
+            end
+
+            if type == "boolean" and (not (def == "true" or def == "false")) and (not def:find(".")) then
+                print(
+                    "WARNING: Property " .. item.name .. " from " .. item.module.name ..
+                    " is a boolean, but is neither `true`, `false` or an alias"
+                )
+            end
+
+            item:add_metadata("Default value", ("<code>%s</code>"):format(def))
+        else
+            -- Properties should have a default value. If they don't or if the
+            -- default depends on the context, then `opt=nil` should be used to
+            -- mute this warning.
+            local auto_opt = nil
+
+            -- This adds a default value. It works for LDoc 1.4.5, but is a
+            -- private API and might break in the future.
+            if item.tags["propertydefault"] and item.tags["propertydefault"][1] then
+                item:add_metadata(
+                    "Default value",
+                    ldoc.markup(item.tags["propertydefault"][1])
+                )
+            elseif auto_opt then
+                local mods = item.modifiers[item.parameter]
+
+                if mods then
+                    mods[item.params[1]].opt = auto_opt
+                end
+
+                item:add_metadata("Default value", ("<code>%s</code>"):format(auto_opt))
+            elseif not sublist then
+                -- The default could not be determined automatically, it requires
+                -- an explicit `opt=<value>`.
+                print(
+                    "WARNING: Property", item.name .. " from " .. item.module.name,
+                    "doesn't have a default value. Add `[opt=value]` to the @tparam"
+                )
+            end
+        end
+    end,
 }
 
 -- Documentation for objects properties
@@ -1711,6 +1815,7 @@ local summarize = {
 
 local no_prefix = {
     property           = true,
+    config             = true,
     signal             = true,
     clientruleproperty = true,
     deprecatedproperty = true,

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -293,7 +293,12 @@ create_type {
     subfield_title = "Parameters",
 }
 
-
+create_type {
+    name           = "config",
+    title          = "Config key",
+    project_level  = false,
+    subfield_title = "Type constraints",
+}
 
 -- Documentation for objects properties
 create_type {
@@ -2274,6 +2279,7 @@ local add_args = {
 local display_type = {
     property           = true,
     beautiful          = true,
+    config             = true,
     field              = true,
     deprecatedproperty = true,
     clientruleproperty = true,

--- a/docs/ldoc.ltp
+++ b/docs/ldoc.ltp
@@ -405,7 +405,7 @@
     <dd>
     $(M(ldoc.descript(item),item))
 
-#  if kind == "Object properties" and item.params[1] and #item.metadata > 0 then
+#  if (kind == "Object properties" or kind == "Config key") and item.params[1] and #item.metadata > 0 then
     <h3>Constraints:</h3>
     <span class="property_type">
       <table class="see_also">

--- a/include/cwc/config.h
+++ b/include/cwc/config.h
@@ -11,18 +11,18 @@ struct cwc_config {
     bool tasklist_show_all;
 
     // client
-    int border_color_rotation_degree;
-    int border_width;
-    int decoration_mode; // enum cwc_toplevel_decoration_mode
+    int border_color_rotation;   // degree
+    int border_width;            // px
+    int default_decoration_mode; // enum cwc_toplevel_decoration_mode
 
     // screen
     int useless_gaps;
 
     // pointer device
     int cursor_size;
-    int cursor_inactive_timeout_ms;
-    int cursor_edge_threshold;
-    float cursor_edge_snapping_overlay_color[4];
+    int cursor_inactive_timeout;                 // milisecond
+    int cursor_edge_threshold;                   // px
+    float cursor_edge_snapping_overlay_color[4]; // rgba
 
     // kbd
     int repeat_rate;

--- a/include/cwc/config.h
+++ b/include/cwc/config.h
@@ -14,8 +14,6 @@ struct cwc_config {
     int border_color_rotation_degree;
     int border_width;
     int decoration_mode; // enum cwc_toplevel_decoration_mode
-    struct _cairo_pattern *border_color_focus;  // USE SETTER
-    struct _cairo_pattern *border_color_normal; // USE SETTER
 
     // screen
     int useless_gaps;
@@ -61,9 +59,6 @@ void cwc_config_init();
 void cwc_config_commit();
 
 void cwc_config_set_default();
-
-void cwc_config_set_cairo_pattern(struct _cairo_pattern **dest,
-                                  struct _cairo_pattern *src);
 
 void cwc_config_set_number_positive(int *dest, int src);
 

--- a/include/cwc/input/keyboard.h
+++ b/include/cwc/input/keyboard.h
@@ -141,4 +141,6 @@ bool keybind_mouse_execute(struct cwc_keybind_map *kmap,
 
 void keybind_register_common_key();
 
+void update_xkb_idle();
+
 #endif // !_CWC_INPUT_KEYBOARD_H

--- a/include/cwc/luac.h
+++ b/include/cwc/luac.h
@@ -109,4 +109,19 @@ static inline cairo_pattern_t *luaC_checkcolor(lua_State *L, int idx)
     return *pattern;
 }
 
+/* return true if top value on the stack is not nil.
+ *
+ * [-0, +1, -]
+ */
+static inline bool luaC_config_get(lua_State *L, const char *key)
+{
+    lua_getglobal(L, "__cwc_config");
+    lua_pushstring(L, key);
+    lua_rawget(L, -2);
+
+    lua_remove(L, -2);
+
+    return !lua_isnil(L, -1);
+}
+
 #endif // !_CWC_LUAC_H

--- a/lib/config.lua
+++ b/lib/config.lua
@@ -87,21 +87,81 @@ function config.check_enum(enum_table)
     end
 end
 
---- The color of client border
--- @config border_color_normal
--- @param gears_color
+--- If `false` it will show only in the active tag otherwise show all client.
+-- @config tasklist_show_all
+-- @tparam[opt=true] boolean tasklist_show_all
 
---- The color of fcoused client border
+--- The color of client border.
+-- @config border_color_normal
+-- @tparam gears_color border_color_normal
+-- @propertydefault `#888888`
+
+--- The color of focused client border.
 -- @config border_color_focus
--- @param gears_color
+-- @tparam gears_color border_color_focus
+-- @propertydefault nil
+
+--- Rotation of the color pattern in degree.
+-- @config border_color_rotation
+-- @tparam[opt=0] gears_color border_color_rotation
+
+--- Thickness of the client border in pixel.
+-- @config border_width
+-- @tparam[opt=0] gears_color border_width
+
+--- Default mode of the client decoration (SSD or CSD).
+-- @config default_decoration_mode
+-- @tparam[opt=0] enum default_decoration_mode
+-- @see cuteful.enum.decoration_mode
 
 --- The size of the cursor
 -- @config cursor_size
--- @param integer
+-- @tparam[opt=24] integer cursor_size
+
+--- Time in miliseconds to hide the cursor (0 means never hide).
+-- @config cursor_inactive_timeout
+-- @tparam[opt=5000] integer cursor_inactive_timeout
+
+--- Distance in pixel from the edge of screen to trigger edge tiling for floating client.
+-- @config cursor_edge_threshold
+-- @tparam[opt=16] integer cursor_edge_threshold
+
+--- Overlay color when edge threshold is active.
+-- @config cursor_edge_snapping_overlay_color
+-- @tparam table cursor_edge_snapping_overlay_color
+-- @propertydefault {0.1, 0.2, 0.4, 0.1}
+
+--- Keyboard repeat rate in hz.
+-- @config repeat_rate
+-- @tparam[opt=30] integer repeat_rate
+
+--- Keyboard repeat delay in miliseconds.
+-- @config repeat_delay
+-- @tparam[opt=400] integer repeat_delay
+
+--- XKB Rules.
+-- @config xkb_rules
+-- @tparam[opt=""] string xkb_rules
+
+--- XKB model.
+-- @config xkb_model
+-- @tparam[opt=""] string xkb_model
+
+--- XKB layout.
+-- @config xkb_layout
+-- @tparam[opt=""] string xkb_layout
+
+--- XKB variant.
+-- @config xkb_variant
+-- @tparam[opt=""] string xkb_variant
+
+--- XKB options.
+-- @config xkb_options
+-- @tparam[opt=""] string xkb_options
 
 --- The gap size between clients
 -- @config useless_gaps
--- @param integer
+-- @tparam[opt=0] integer useless_gaps
 
 -- sanity check table either a string (the type) or a function that return a boolean that determine if
 -- it pass the sanity check (true) or not (false)
@@ -110,7 +170,7 @@ local sanity_check = {
 
     border_color_normal                = config.check_color,
     border_color_focus                 = config.check_color,
-    border_color_rotation_degree       = "number",
+    border_color_rotation              = config.check_positive,
     border_width                       = config.check_positive,
     default_decoration_mode            = config.check_enum(enum.decoration_mode),
 
@@ -128,7 +188,9 @@ local sanity_check = {
     xkb_options                        = "string",
 }
 
---- Check if item is a positive number.
+--- Add a checker before to constraint value before writing it to the config table.
+--
+-- If the key exist it will throw error.
 --
 -- @staticfct sanity_check_add
 -- @tparam string key Config key to add.

--- a/lib/config.lua
+++ b/lib/config.lua
@@ -111,7 +111,7 @@ end
 
 --- Default mode of the client decoration (SSD or CSD).
 -- @config default_decoration_mode
--- @tparam[opt=0] enum default_decoration_mode
+-- @tparam[opt=SERVER_SIDE] enum default_decoration_mode
 -- @see cuteful.enum.decoration_mode
 
 --- The size of the cursor

--- a/lib/config.lua
+++ b/lib/config.lua
@@ -1,0 +1,176 @@
+---------------------------------------------------------------------------
+--- High level interface to the private `__cwc_config` global table.
+--
+-- any write on the config table will automatically be taken care of,
+-- so no need to manually call `cwc.commit`.
+--
+-- @author Dwi Asmoro Bangun
+-- @copyright 2025
+-- @license GPLv3
+-- @module config
+---------------------------------------------------------------------------
+
+local enum           = require("cuteful.enum")
+local gears          = require("gears")
+local gtable         = gears.table
+local protected_call = gears.protected_call
+local print_error    = gears.debug.print_error
+
+local cwc            = cwc
+local __cwc_config   = __cwc_config
+local config         = { mt = {} }
+
+--- Merge source table to the config table.
+--
+-- @tparam string|table src The configuration table to load. It can be either the path to the config
+-- file (which should return a table) or directly a table containing all the config value.
+-- @treturn boolean True if successful, false otherwise.
+-- @staticfct init
+function config.init(src)
+    if type(src) == "table" then
+        gtable.crush(config, src)
+        cwc.commit()
+        return true
+    end
+
+    if type(src) == "string" then
+        local result = protected_call(dofile, src)
+        if not result or type(result) ~= "table" then
+            print_error("config: the resulted file doesn't return a table")
+            return false
+        end
+
+        gtable.crush(config, result)
+        cwc.commit()
+        return true
+    end
+
+    print_error("config: source is not a table nor a string")
+    return false
+end
+
+--- Check if item is created from `gears.color`.
+--
+-- @staticfct color_check
+-- @tparam gears_color item Item to check.
+-- @treturn boolean
+function config.check_color(item)
+    if tostring(item):match("cairo") then return true end
+
+    return false
+end
+
+--- Check if item is a positive number.
+--
+-- @staticfct positive
+-- @tparam number item Item to check.
+-- @treturn boolean
+function config.check_positive(item)
+    if item >= 0 then return true end
+
+    return false
+end
+
+--- Check if item is a positive number.
+--
+-- @staticfct check_enum
+-- @tparam number item Item to check.
+-- @tparam table enum_table The enum table.
+-- @treturn boolean
+function config.check_enum(enum_table)
+    return function(item)
+        for _, pair in pairs(enum_table) do
+            if item == pair then return true end
+        end
+
+        return false
+    end
+end
+
+--- The color of client border
+-- @config border_color_normal
+-- @param gears_color
+
+--- The color of fcoused client border
+-- @config border_color_focus
+-- @param gears_color
+
+--- The size of the cursor
+-- @config cursor_size
+-- @param integer
+
+--- The gap size between clients
+-- @config useless_gaps
+-- @param integer
+
+-- sanity check table either a string (the type) or a function that return a boolean that determine if
+-- it pass the sanity check (true) or not (false)
+local sanity_check = {
+    tasklist_show_all                  = "boolean",
+
+    border_color_normal                = config.check_color,
+    border_color_focus                 = config.check_color,
+    border_color_rotation_degree       = "number",
+    border_width                       = config.check_positive,
+    default_decoration_mode            = config.check_enum(enum.decoration_mode),
+
+    useless_gaps                       = config.check_positive,
+
+    cursor_size                        = config.check_positive,
+    cursor_inactive_timeout            = config.check_positive,
+    cursor_edge_threshold              = config.check_positive,
+    cursor_edge_snapping_overlay_color = "table", -- TODO: proper checking
+
+    repeat_rate                        = config.check_positive,
+    repeat_delay                       = config.check_positive,
+    xkb_variant                        = "string",
+    xkb_layout                         = "string",
+    xkb_options                        = "string",
+}
+
+--- Check if item is a positive number.
+--
+-- @staticfct sanity_check_add
+-- @tparam string key Config key to add.
+-- @tparam function|string checker Function or data type as a tester.
+-- @noreturn
+function config.sanity_check_add(key, checker)
+    if sanity_check[key] then
+        return print_error("config: sanity check for `" .. key .. "` already exist")
+    end
+
+    sanity_check[key] = checker
+end
+
+local is_committed = false
+local function delayed_commit()
+    if is_committed then return end
+
+    cwc.timer.delayed_call(function()
+        cwc.commit()
+        is_committed = false
+    end)
+
+    is_committed = true
+end
+
+config.mt.__index    = function(t, k)
+    return rawget(__cwc_config, k)
+end
+
+config.mt.__newindex = function(t, k, v)
+    local sanity_val = sanity_check[k]
+
+    local sanity_type = type(sanity_val)
+
+    if (sanity_type == "string" and type(v) ~= sanity_val) or
+        (sanity_type == "function" and not sanity_val(v)) then
+        print_error("config: key " .. k .. " is not using the right type")
+        return
+    end
+
+    rawset(__cwc_config, k, v)
+    delayed_commit()
+end
+
+return setmetatable(config, config.mt)

--- a/lib/config.lua
+++ b/lib/config.lua
@@ -71,12 +71,12 @@ function config.check_positive(item)
     return false
 end
 
---- Check if item is a positive number.
+--- Return a function that will check if item is a part of the passed enum table.
 --
 -- @staticfct check_enum
 -- @tparam number item Item to check.
 -- @tparam table enum_table The enum table.
--- @treturn boolean
+-- @treturn function
 function config.check_enum(enum_table)
     return function(item)
         for _, pair in pairs(enum_table) do
@@ -93,13 +93,13 @@ end
 
 --- The color of client border.
 -- @config border_color_normal
--- @tparam gears_color border_color_normal
--- @propertydefault `#888888`
+-- @tparam[opt=#888888] gears_color border_color_normal
+-- @see gears.color
 
 --- The color of focused client border.
 -- @config border_color_focus
--- @tparam gears_color border_color_focus
--- @propertydefault nil
+-- @tparam[opt=#888888] gears_color border_color_focus
+-- @see gears.color
 
 --- Rotation of the color pattern in degree.
 -- @config border_color_rotation
@@ -197,7 +197,7 @@ local sanity_check = {
 -- @tparam function|string checker Function or data type as a tester.
 -- @noreturn
 function config.sanity_check_add(key, checker)
-    if sanity_check[key] then
+    if sanity_check[key] ~= nil then
         return print_error("config: sanity check for `" .. key .. "` already exist")
     end
 

--- a/lib/config.lua
+++ b/lib/config.lua
@@ -4,6 +4,11 @@
 -- any write on the config table will automatically be taken care of,
 -- so no need to manually call `cwc.commit`.
 --
+-- @usage local config = require("config")
+--
+-- config["cursor_size"] = 25
+-- config["cursor_edge_snapping_overlay_color"] = { 0.1, 0.2, 0.3, 0.05 }
+--
 -- @author Dwi Asmoro Bangun
 -- @copyright 2025
 -- @license GPLv3
@@ -103,11 +108,11 @@ end
 
 --- Rotation of the color pattern in degree.
 -- @config border_color_rotation
--- @tparam[opt=0] gears_color border_color_rotation
+-- @tparam[opt=0] integer border_color_rotation
 
 --- Thickness of the client border in pixel.
 -- @config border_width
--- @tparam[opt=0] gears_color border_width
+-- @tparam[opt=0] integer border_width
 
 --- Default mode of the client decoration (SSD or CSD).
 -- @config default_decoration_mode

--- a/lib/impl/border.lua
+++ b/lib/impl/border.lua
@@ -1,0 +1,41 @@
+local gears = require("gears")
+local config = require("config")
+
+local cwc = cwc
+
+local focus = config["border_color_focus"]
+local normal = config["border_color_normal"]
+
+cwc.connect_signal("client::focus", function(c)
+    c.border_color = focus
+end)
+
+cwc.connect_signal("client::unfocus", function(c)
+    c.border_color = normal
+end)
+
+cwc.connect_signal("client::swap", function(...)
+    local clients = { ... }
+    local focused = cwc.client.focused()
+    for _, c in pairs(clients) do
+        if focused == c then
+            c.border_color = focus
+        else
+            c.border_color = normal
+        end
+    end
+end)
+
+cwc.connect_signal("container::swap", function(...)
+    local conts = { ... }
+    local focused = cwc.client.focused()
+    for _, cont in ipairs(conts) do
+        cont.front.border_color = normal
+        for _, c in ipairs(cont.clients) do
+            if c == focused then
+                c.border_color = focus
+                break
+            end
+        end
+    end
+end)

--- a/lib/impl/init.lua
+++ b/lib/impl/init.lua
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------
---- Default implementation that can be disabled.
+--- Default implementation that optionally enabled.
 --
 -- `impl.border` - Manage the client border color based on it states.
 --
@@ -9,14 +9,14 @@
 -- @module impl
 ---------------------------------------------------------------------------
 
---- Use all implementation available.
+--- Use implementation that provide core functionality.
 --
--- @staticfct use_all
+-- @staticfct use_core
 -- @noreturn
-local function use_all()
+local function use_core()
     require("impl.border")
 end
 
 return {
-    use_all = use_all
+    use_core = use_core
 }

--- a/lib/impl/init.lua
+++ b/lib/impl/init.lua
@@ -1,5 +1,7 @@
 ---------------------------------------------------------------------------
---- Implementation of various things (battery included type shi).
+--- Default implementation that can be disabled.
+--
+-- `impl.border` - Manage the client border color based on it states.
 --
 -- @author Dwi Asmoro Bangun
 -- @copyright 2025
@@ -7,6 +9,10 @@
 -- @module impl
 ---------------------------------------------------------------------------
 
+--- Use all implementation available.
+--
+-- @staticfct use_all
+-- @noreturn
 local function use_all()
     require("impl.border")
 end

--- a/lib/impl/init.lua
+++ b/lib/impl/init.lua
@@ -1,0 +1,16 @@
+---------------------------------------------------------------------------
+--- Implementation of various things (battery included type shi).
+--
+-- @author Dwi Asmoro Bangun
+-- @copyright 2025
+-- @license GPLv3
+-- @module impl
+---------------------------------------------------------------------------
+
+local function use_all()
+    require("impl.border")
+end
+
+return {
+    use_all = use_all
+}

--- a/plugins/cwcle.c
+++ b/plugins/cwcle.c
@@ -64,8 +64,13 @@ static void raise_next_container(struct cwc_container *current)
             continue;
 
         if (cwc_container_is_visible(container)) {
-            cwc_border_set_pattern(&current->border,
-                                   g_config.border_color_normal);
+            cairo_pattern_t *pattern = NULL;
+            lua_State *L             = g_config_get_lua_State();
+            if (luaC_config_get(L, "border_color_normal"))
+                pattern = cairo_pattern_reference(
+                    *(cairo_pattern_t **)lua_touserdata(L, -1));
+            cwc_border_set_pattern(&current->border, pattern);
+            cairo_pattern_destroy(pattern);
             raise_container(container);
             break;
         }
@@ -84,8 +89,13 @@ static void raise_prev_container(struct cwc_container *current)
             continue;
 
         if (cwc_container_is_visible(container)) {
-            cwc_border_set_pattern(&current->border,
-                                   g_config.border_color_normal);
+            cairo_pattern_t *pattern = NULL;
+            lua_State *L             = g_config_get_lua_State();
+            if (luaC_config_get(L, "border_color_normal"))
+                pattern = cairo_pattern_reference(
+                    *(cairo_pattern_t **)lua_touserdata(L, -1));
+            cwc_border_set_pattern(&current->border, pattern);
+            cairo_pattern_destroy(pattern);
             raise_container(container);
             break;
         }

--- a/plugins/cwcle.c
+++ b/plugins/cwcle.c
@@ -23,8 +23,13 @@
 #include "cwc/plugin.h"
 #include "cwc/server.h"
 #include "cwc/signal.h"
+#include "cwc/util.h"
 
-static cairo_pattern_t *raised_pattern = NULL;
+/** The border color when the client is raised.
+ * @config border_color_raised
+ * @tparam[opt=#ffaaff] gears_color border_color_raised
+ * @see gears.color
+ */
 
 static struct lifecwcle {
     struct cwc_container *raised;
@@ -34,6 +39,7 @@ static struct lifecwcle {
     uint32_t modifier;
 
     struct wl_listener on_modifier_l;
+    struct wl_listener on_commit_l;
 } lifecwcle = {0};
 
 static void stop_cycle()
@@ -47,7 +53,16 @@ static void stop_cycle()
 
 static void raise_container(struct cwc_container *container)
 {
+
+    cairo_pattern_t *raised_pattern = NULL;
+    lua_State *L                    = g_config_get_lua_State();
+    if (luaC_config_get(L, "border_color_raised"))
+        raised_pattern =
+            cairo_pattern_reference(*(cairo_pattern_t **)lua_touserdata(L, -1));
+
     cwc_border_set_pattern(&container->border, raised_pattern);
+    cairo_pattern_destroy(raised_pattern);
+
     wlr_scene_node_raise_to_top(&container->tree->node);
     lifecwcle.raised = container;
 }
@@ -69,8 +84,10 @@ static void raise_next_container(struct cwc_container *current)
             if (luaC_config_get(L, "border_color_normal"))
                 pattern = cairo_pattern_reference(
                     *(cairo_pattern_t **)lua_touserdata(L, -1));
+
             cwc_border_set_pattern(&current->border, pattern);
             cairo_pattern_destroy(pattern);
+
             raise_container(container);
             break;
         }
@@ -94,8 +111,10 @@ static void raise_prev_container(struct cwc_container *current)
             if (luaC_config_get(L, "border_color_normal"))
                 pattern = cairo_pattern_reference(
                     *(cairo_pattern_t **)lua_touserdata(L, -1));
+
             cwc_border_set_pattern(&current->border, pattern);
             cairo_pattern_destroy(pattern);
+
             raise_container(container);
             break;
         }
@@ -166,22 +185,6 @@ static int luaC_enter_cycle_prev(lua_State *L)
     return 0;
 }
 
-/** Set the border of toplevel when raised.
- *
- * @tparam cairo_pattern_t color Color from gears.color
- * @configfct set_border_color_raised
- * @noreturn
- * @see gears.color
- */
-static int luaC_set_border_color_raised(lua_State *L)
-{
-    cairo_pattern_t *pattern = luaC_checkcolor(L, 1);
-    cairo_pattern_destroy(raised_pattern);
-    raised_pattern = cairo_pattern_reference(pattern);
-
-    return 0;
-}
-
 static void on_kbd_mod(struct wl_listener *listener, void *data)
 {
     uint32_t mod = wlr_keyboard_get_modifiers(lifecwcle.kbd);
@@ -197,13 +200,22 @@ void setup_cwcle(void *data)
 
     lifecwcle.on_modifier_l.notify = on_kbd_mod;
     wl_signal_add(&kbd->events.modifiers, &lifecwcle.on_modifier_l);
+
+    const char *setup_luacode =
+        "local config = require(\"config\")\n"
+        "local gears = require(\"gears\")\n"
+        "\n"
+        "config.sanity_check_add(\"border_color_raised\", config.check_color)\n"
+        "config[\"border_color_raised\"] = gears.color(\"#ffaaff\")\n";
+
+    lua_State *L = g_config_get_lua_State();
+    cwc_assert(!luaL_dostring(L, setup_luacode), "incorrect lua code");
 }
 
 static const luaL_Reg cwcle_staticlibs[] = {
-    {"next",                    luaC_enter_cycle_next       },
-    {"prev",                    luaC_enter_cycle_prev       },
-    {"set_border_color_raised", luaC_set_border_color_raised},
-    {NULL,                      NULL                        },
+    {"next", luaC_enter_cycle_next},
+    {"prev", luaC_enter_cycle_prev},
+    {NULL,   NULL                 },
 };
 
 static void register_lualibs(void *data)
@@ -251,10 +263,6 @@ static void on_cwc_shutdown(void *data)
 
 static int cwcle_init()
 {
-    // default to purple
-    raised_pattern =
-        cairo_pattern_create_rgba(0xff / 255.0, 0xaa / 255.0, 0xff / 255.0, 1);
-
     /* since the module loaded before the server initialized which mean the
      * seat hasn't been created yet, we register the keyboard modifier signal
      * when the event loop run. */

--- a/src/config.c
+++ b/src/config.c
@@ -47,11 +47,11 @@ static void on_commit(struct wl_listener *listener, void *data)
         g_config.tasklist_show_all = lua_toboolean(L, -1);
 
     if (luaC_config_get(L, "border_color_rotation"))
-        g_config.border_color_rotation_degree = lua_tointeger(L, -1);
+        g_config.border_color_rotation = lua_tointeger(L, -1);
     if (luaC_config_get(L, "border_width"))
         g_config.border_width = lua_tointeger(L, -1);
     if (luaC_config_get(L, "default_decoration_mode"))
-        g_config.decoration_mode = lua_tointeger(L, -1);
+        g_config.default_decoration_mode = lua_tointeger(L, -1);
 
     if (luaC_config_get(L, "useless_gaps")) {
         g_config.useless_gaps = lua_tointeger(L, -1);
@@ -60,7 +60,7 @@ static void on_commit(struct wl_listener *listener, void *data)
     if (luaC_config_get(L, "cursor_size"))
         g_config.cursor_size = lua_tointeger(L, -1);
     if (luaC_config_get(L, "cursor_inactive_timeout"))
-        g_config.cursor_inactive_timeout_ms = lua_tointeger(L, -1);
+        g_config.cursor_inactive_timeout = lua_tointeger(L, -1);
     if (luaC_config_get(L, "cursor_edge_threshold"))
         g_config.cursor_edge_threshold = lua_tointeger(L, -1);
     if (luaC_config_get(L, "cursor_edge_snapping_overlay_color")) {
@@ -105,13 +105,13 @@ void cwc_config_set_default()
 {
     g_config.tasklist_show_all = true;
 
-    g_config.border_color_rotation_degree = 0;
-    g_config.useless_gaps                 = 0;
-    g_config.border_width                 = 1;
-    g_config.decoration_mode              = CWC_TOPLEVEL_DECORATION_SERVER_SIDE;
+    g_config.border_color_rotation   = 0;
+    g_config.useless_gaps            = 0;
+    g_config.border_width            = 1;
+    g_config.default_decoration_mode = CWC_TOPLEVEL_DECORATION_SERVER_SIDE;
 
     g_config.cursor_size                           = 24;
-    g_config.cursor_inactive_timeout_ms            = 5000;
+    g_config.cursor_inactive_timeout               = 5000;
     g_config.cursor_edge_threshold                 = 16;
     g_config.cursor_edge_snapping_overlay_color[0] = 0.1;
     g_config.cursor_edge_snapping_overlay_color[1] = 0.2;

--- a/src/config.c
+++ b/src/config.c
@@ -45,7 +45,7 @@ static void on_commit(struct wl_listener *listener, void *data)
     if (luaC_config_get(L, "tasklist_show_all"))
         g_config.tasklist_show_all = lua_toboolean(L, -1);
 
-    if (luaC_config_get(L, "border_color_rotation_degree"))
+    if (luaC_config_get(L, "border_color_rotation"))
         g_config.border_color_rotation_degree = lua_tointeger(L, -1);
     if (luaC_config_get(L, "border_width"))
         g_config.border_width = lua_tointeger(L, -1);

--- a/src/config.c
+++ b/src/config.c
@@ -28,6 +28,7 @@
 #include "cwc/input/keyboard.h"
 #include "cwc/luac.h"
 #include "cwc/util.h"
+#include "lauxlib.h"
 
 static struct wl_listener commit_listener;
 
@@ -102,14 +103,12 @@ void cwc_config_commit()
 
 void cwc_config_set_default()
 {
-    g_config.tasklist_show_all            = true;
+    g_config.tasklist_show_all = true;
+
     g_config.border_color_rotation_degree = 0;
-    g_config.border_color_focus           = NULL;
-    g_config.border_color_normal =
-        cairo_pattern_create_rgba(127 / 255.0, 127 / 255.0, 127 / 255.0, 1);
-    g_config.useless_gaps    = 0;
-    g_config.border_width    = 1;
-    g_config.decoration_mode = CWC_TOPLEVEL_DECORATION_SERVER_SIDE;
+    g_config.useless_gaps                 = 0;
+    g_config.border_width                 = 1;
+    g_config.decoration_mode              = CWC_TOPLEVEL_DECORATION_SERVER_SIDE;
 
     g_config.cursor_size                           = 24;
     g_config.cursor_inactive_timeout_ms            = 5000;
@@ -126,14 +125,6 @@ void cwc_config_set_default()
     g_config.xkb_layout   = NULL;
     g_config.xkb_variant  = NULL;
     g_config.xkb_options  = NULL;
-}
-
-void cwc_config_set_cairo_pattern(cairo_pattern_t **dst, cairo_pattern_t *src)
-{
-    if (g_config.border_color_focus)
-        cairo_pattern_destroy(*dst);
-
-    *dst = cairo_pattern_reference(src);
 }
 
 void cwc_config_set_number_positive(int *dest, int src)

--- a/src/config.c
+++ b/src/config.c
@@ -30,7 +30,7 @@
 #include "cwc/util.h"
 #include "lauxlib.h"
 
-static struct wl_listener commit_listener;
+static struct wl_listener on_commit_l;
 
 #define UPDATE_XKB_OPTIONS(opt_name)                               \
     if (luaC_config_get(L, "xkb_" #opt_name)) {                    \
@@ -90,8 +90,8 @@ void cwc_config_init()
     memcpy(g_config.old_config, &g_config, sizeof(g_config));
     wl_signal_init(&g_config.events.commit);
 
-    commit_listener.notify = on_commit;
-    wl_signal_add(&g_config.events.commit, &commit_listener);
+    on_commit_l.notify = on_commit;
+    wl_signal_add(&g_config.events.commit, &on_commit_l);
 }
 
 void cwc_config_commit()

--- a/src/defaultcfg.lua
+++ b/src/defaultcfg.lua
@@ -1,0 +1,27 @@
+local gears = require("gears")
+local enum = require("cuteful.enum")
+
+__cwc_config = {
+    tasklist_show_all                  = true,
+
+    border_color_rotation              = 0,
+    border_width                       = 1,
+    default_decoration_mode            = enum.decoration_mode.SERVER_SIDE,
+    border_color_focus                 = gears.color("#888888"),
+    border_color_normal                = gears.color("#888888"),
+
+    useless_gaps                       = 3,
+
+    cursor_size                        = 24,
+    cursor_inactive_timeout            = 5000,
+    cursor_edge_threshold              = 16,
+    cursor_edge_snapping_overlay_color = { 0.1, 0.2, 0.4, 0.1 },
+
+    repeat_rate                        = 30,
+    repeat_delay                       = 400,
+    xkb_rules                          = "",
+    xkb_model                          = "",
+    xkb_layout                         = "",
+    xkb_variant                        = "",
+    xkb_options                        = "",
+}

--- a/src/desktop/toplevel.c
+++ b/src/desktop/toplevel.c
@@ -268,7 +268,8 @@ static void _surface_initial_commit(struct cwc_toplevel *toplevel)
             // | WLR_XDG_TOPLEVEL_WM_CAPABILITIES_MINIMIZE
             | WLR_XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN);
 
-    cwc_toplevel_set_decoration_mode(toplevel, g_config.decoration_mode);
+    cwc_toplevel_set_decoration_mode(toplevel,
+                                     g_config.default_decoration_mode);
 }
 
 static void on_surface_commit(struct wl_listener *listener, void *data)
@@ -859,7 +860,7 @@ static void on_new_toplevel_decoration(struct wl_listener *listener, void *data)
     toplevel->decoration = cwc_deco;
 
     cwc_deco->base                         = deco;
-    cwc_deco->mode                         = g_config.decoration_mode;
+    cwc_deco->mode                         = g_config.default_decoration_mode;
     cwc_deco->set_decoration_mode_l.notify = on_set_decoration_mode;
     cwc_deco->destroy_l.notify             = on_decoration_destroy;
     wl_signal_add(&deco->events.request_mode, &cwc_deco->set_decoration_mode_l);

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -307,7 +307,7 @@ void process_cursor_motion(struct cwc_cursor *cursor,
 
     cwc_cursor_unhide(cursor);
     wl_event_source_timer_update(cursor->inactive_timer,
-                                 g_config.cursor_inactive_timeout_ms);
+                                 g_config.cursor_inactive_timeout);
     wlr_idle_notifier_v1_notify_activity(server.idle->idle_notifier, wlr_seat);
 
     switch (cursor->state) {

--- a/src/layout/container.c
+++ b/src/layout/container.c
@@ -583,9 +583,8 @@ void cwc_container_init(struct cwc_output *output,
         pattern =
             cairo_pattern_reference(*(cairo_pattern_t **)lua_touserdata(L, -1));
 
-    cwc_border_init(&cont->border, pattern,
-                    g_config.border_color_rotation_degree, cont->width,
-                    cont->height, border_w);
+    cwc_border_init(&cont->border, pattern, g_config.border_color_rotation,
+                    cont->width, cont->height, border_w);
     cairo_pattern_destroy(pattern);
 
     cwc_border_attach_to_scene(&cont->border, cont->tree);

--- a/src/luac.c
+++ b/src/luac.c
@@ -570,6 +570,9 @@ int luaC_init()
     cwc_assert(
         !luaL_dostring(L, "awesome = { connect_signal = function() end}"),
         "incorrect dostring");
+
+    // config table
+    cwc_assert(!luaL_dostring(L, "__cwc_config = {}"), "incorrect dostring");
     lua_settop(L, 0);
 
     // reg c lib

--- a/src/luac.c
+++ b/src/luac.c
@@ -42,6 +42,7 @@
 #include <wlr/backend/x11.h>
 #include <wlr/types/wlr_session_lock_v1.h>
 
+#include "cwc-luagen.h"
 #include "cwc/config.h"
 #include "cwc/desktop/layer_shell.h"
 #include "cwc/desktop/output.h"
@@ -568,11 +569,13 @@ int luaC_init()
 
     // awesome compability for awesome module
     cwc_assert(
-        !luaL_dostring(L, "awesome = { connect_signal = function() end}"),
+        !luaL_dostring(L, "awesome = { connect_signal = function() end }"),
         "incorrect dostring");
 
     // config table
-    cwc_assert(!luaL_dostring(L, "__cwc_config = {}"), "incorrect dostring");
+    cwc_assert(
+        !luaL_dostring(g_config_get_lua_State(), (char *)_src_defaultcfg_lua),
+        "incorrect dostring");
     lua_settop(L, 0);
 
     // reg c lib

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,19 @@
+assets = {
+  'config': 'defaultcfg.lua',
+}
+
+script_assets = []
+foreach _, path : assets
+  script_assets += path
+endforeach
+
+script_header = custom_target(
+  name.underscorify() + '_h',
+  input: script_assets,
+  output: 'cwc-luagen.h',
+  command: ['python', meson.source_root() / 'cwctl/gen.py', '@INPUT@', '@OUTPUT@'],
+)
+
 srcs = [
   'main.c',
   'server.c',
@@ -69,6 +85,8 @@ srcs = [
   protocols_server_header['wlr-output-power-management-unstable-v1'],
   protocols_server_header['dwl-ipc-unstable-v2'],
   protocols_code['dwl-ipc-unstable-v2'],
+
+  script_header,
 ]
 
 executable(

--- a/src/objects/client.c
+++ b/src/objects/client.c
@@ -381,36 +381,6 @@ static int luaC_client_set_border_width_cfg(lua_State *L)
     return 0;
 }
 
-/** Set the default border color for focused client.
- *
- * @configfct set_border_color_focus
- * @tparam pattern cairo_pattern_t Cairo pattern object from gears.color
- * @noreturn
- * @see gears.color
- */
-static int luaC_client_set_border_color_focus(lua_State *L)
-{
-    cairo_pattern_t *pattern = luaC_checkcolor(L, 1);
-    cwc_config_set_cairo_pattern(&g_config.border_color_focus, pattern);
-
-    return 0;
-}
-
-/** Set the default border color for toplevel.
- *
- * @configfct set_border_color_normal
- * @tparam pattern cairo_pattern_t Cairo pattern object from gears.color
- * @noreturn
- * @see gears.color
- */
-static int luaC_client_set_border_color_normal(lua_State *L)
-{
-    cairo_pattern_t *pattern = luaC_checkcolor(L, 1);
-    cwc_config_set_cairo_pattern(&g_config.border_color_normal, pattern);
-
-    return 0;
-}
-
 /** Set the border color rotation config in degree
  *
  * @configfct set_border_color_rotation
@@ -1275,8 +1245,6 @@ void luaC_client_setup(lua_State *L)
         FIELD(default_decoration_mode),
 
         {"set_border_width",          luaC_client_set_border_width_cfg     },
-        {"set_border_color_focus",    luaC_client_set_border_color_focus   },
-        {"set_border_color_normal",   luaC_client_set_border_color_normal  },
         {"set_border_color_rotation", luaC_client_set_border_color_rotation},
         {NULL,                        NULL                                 },
     };

--- a/src/objects/client.c
+++ b/src/objects/client.c
@@ -346,7 +346,7 @@ static int luaC_client_focused(lua_State *L)
  */
 static int luaC_client_get_default_decoration_mode(lua_State *L)
 {
-    lua_pushnumber(L, g_config.decoration_mode);
+    lua_pushnumber(L, g_config.default_decoration_mode);
     return 1;
 }
 static int luaC_client_set_default_decoration_mode(lua_State *L)
@@ -362,7 +362,7 @@ static int luaC_client_set_default_decoration_mode(lua_State *L)
     default:
         luaL_error(L, "Invalid decoration mode value: %d", deco_mode);
     }
-    g_config.decoration_mode = deco_mode;
+    g_config.default_decoration_mode = deco_mode;
     return 0;
 }
 
@@ -391,7 +391,7 @@ static int luaC_client_set_border_color_rotation(lua_State *L)
 {
     int rot = luaL_checkint(L, 1);
 
-    g_config.border_color_rotation_degree = rot;
+    g_config.border_color_rotation = rot;
 
     return 0;
 }

--- a/src/objects/pointer.c
+++ b/src/objects/pointer.c
@@ -258,14 +258,14 @@ static int luaC_pointer_set_cursor_size(lua_State *L)
  */
 static int luaC_pointer_get_inactive_timeout(lua_State *L)
 {
-    lua_pushnumber(L, g_config.cursor_inactive_timeout_ms);
+    lua_pushnumber(L, g_config.cursor_inactive_timeout);
     return 1;
 }
 static int luaC_pointer_set_inactive_timeout(lua_State *L)
 {
     int seconds = luaL_checkint(L, 1);
 
-    g_config.cursor_inactive_timeout_ms = seconds * 1000;
+    g_config.cursor_inactive_timeout = seconds * 1000;
     return 0;
 }
 

--- a/src/objects/tag.c
+++ b/src/objects/tag.c
@@ -310,7 +310,6 @@ void luaC_tag_setup(lua_State *L)
         {"view_only",        luaC_tag_view_only   },
         {"strategy_idx",     luaC_tag_strategy_idx},
 
-        // TODO: remove this on v0.1
         {"get_useless_gaps", luaC_tag_get_gap     },
         {"set_useless_gaps", luaC_tag_set_gap     },
 


### PR DESCRIPTION
Unfortunately there are breaking change introduces in this commit.
These functions has been deleted:

- `cwc.client.set_border_color_rotation`
- `cwc.client.set_border_color_normal`
- `cwc.cwcle.set_border_color_raised`

The reason for this change is because there is no way to convert from cairo pattern back to the lua lgi object which is needed for migrating border color implementation from C to lua.