### PR TITLE
docs(rc.lua): clarify screen position requirements

### DIFF
--- a/defconfig/rc.lua
+++ b/defconfig/rc.lua
@@ -45,7 +45,7 @@ end)
 cwc.connect_signal("screen::new", function(screen)
     -- screen settings
     if screen.name == "DP-1" then
-        screen:set_position(0, 0) -- NOTE: Position(s) MUST be non-zero - based on #49 (https://github.com/Cudiph/cwcwm/issues/49).
+        screen:set_position(0, 0) -- NOTE: Position(s) MUST be non-negative - based on #49 (https://github.com/Cudiph/cwcwm/issues/49).
 
         screen:set_mode(1920, 1080, 60) -- width, height, refresh rate
         screen:set_adaptive_sync(true)


### PR DESCRIPTION
Update documentation for `screen:set_position()` to explain that positions must be non‑negative. This change references issue #49, which notes that setting a position less than 0 can cause unpredictable application behavior.