### PR TITLE
nix: fix wrapGAppsHook being renamed

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1766653575,
+        "narHash": "sha256-TPgxCS7+hWc4kPhzkU5dD2M5UuPhLuuaMNZ/IpwKQvI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "3c1016e6acd16ad96053116d0d3043029c9e2649",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -26,7 +26,7 @@
   python3Minimal,
   boost,
   makeWrapper,
-  wrapGAppsHook,
+  wrapGAppsHook3,
   gtk3Support ? false,
   gtk3 ? null,
 }:
@@ -61,7 +61,7 @@ in
       python3Minimal
       boost
       makeWrapper
-      wrapGAppsHook
+      wrapGAppsHook3
       gobject-introspection
     ];
 

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -11,7 +11,7 @@ in {
       enable = lib.mkEnableOption "Enable cwc wayland compositor";
       package = lib.mkOption {
         type = lib.types.package;
-        default = self.packages.${pkgs.system}.cwc;
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.cwc;
         description = "The cwc package to use";
       };
     };


### PR DESCRIPTION
This only fixes evaluation errors with newer commits of nixpkgs-unstable.

CwC does not currently build on NixOS due to some weird GCC issue with hyprutils:
```
/nix/store/dc9vaz50jg7mibk9xvqw5dqv89cxzla3-binutils-2.44/bin/ld: /nix/store/rqjkpbdqq2sycbf0iv8nash6qqqh2i68-hyprutils-0.11.0/lib/libhyprutils.so.10: undefined reference to `std::__format::__with_encoding_conversion(std::locale const&)@GLIBCXX_3.4.34'
/nix/store/dc9vaz50jg7mibk9xvqw5dqv89cxzla3-binutils-2.44/bin/ld: /nix/store/rqjkpbdqq2sycbf0iv8nash6qqqh2i68-hyprutils-0.11.0/lib/libhyprutils.so.10: undefined reference to `std::__format::__locale_encoding_to_utf8(std::locale const&, std::basic_string_view<char, std::char_traits<char> >, void*)@GLIBCXX_3.4.34'
```