### PR TITLE
toplevel: assign resize serial to toplevel only when it visible

### DIFF
--- a/src/layout/container.c
+++ b/src/layout/container.c
@@ -1344,6 +1344,7 @@ static void all_toplevel_set_size(struct cwc_toplevel *toplevel, void *data)
         .height = surf_h,
     };
 
+    bool visible = cwc_toplevel_is_visible(toplevel);
     if (!cwc_toplevel_is_x11(toplevel)) {
         // when floating we respect the min width
         if (cwc_toplevel_is_floating(toplevel)) {
@@ -1356,11 +1357,14 @@ static void all_toplevel_set_size(struct cwc_toplevel *toplevel, void *data)
         clip.x = geom.x;
         clip.y = geom.y;
 
-        if (cwc_toplevel_is_visible(toplevel) && !toplevel->resize_serial)
+        if (visible && !toplevel->resize_serial)
             server.resize_count = MAX(1, server.resize_count + 1);
     }
 
-    toplevel->resize_serial = cwc_toplevel_set_size(toplevel, surf_w, surf_h);
+    uint32_t resize_serial = cwc_toplevel_set_size(toplevel, surf_w, surf_h);
+    if (visible)
+        toplevel->resize_serial = resize_serial;
+
     wlr_scene_subsurface_tree_set_clip(&toplevel->surf_tree->node, &clip);
     box->width  = surf_w;
     box->height = surf_h;


### PR DESCRIPTION
When inserting container to bsp node it instantly resizing instead of scheduling in transaction so the resize serial already has value and the resize count will not change causing it to not wait for the surface ready.

fixes #62