### PR TITLE
nix: add wlroots_0_20 definition so that it compiles

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766653575,
-        "narHash": "sha256-TPgxCS7+hWc4kPhzkU5dD2M5UuPhLuuaMNZ/IpwKQvI=",
+        "lastModified": 1772956932,
+        "narHash": "sha256-M0yS4AafhKxPPmOHGqIV0iKxgNO8bHDWdl1kOwGBwRY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c1016e6acd16ad96053116d0d3043029c9e2649",
+        "rev": "608d0cadfed240589a7eea422407a547ad626a14",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,13 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = {
-    self,
-    flake-parts,
-    ...
-  } @ inputs:
-    flake-parts.lib.mkFlake {inherit inputs;} {
+  outputs =
+    {
+      self,
+      flake-parts,
+      ...
+    }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         inputs.flake-parts.flakeModules.easyOverlay
       ];
@@ -18,31 +19,34 @@
         nixosModules.cwc = import ./nix/nixos-module.nix self;
       };
 
-      perSystem = {
-        config,
-        pkgs,
-        ...
-      }: let
-        inherit
-          (pkgs)
-          callPackage
-          ;
-        cwc = callPackage ./nix/default.nix {};
-        shellOverride = old: {
-          nativeBuildInputs = old.nativeBuildInputs ++ [];
-          buildInputs = old.buildInputs ++ [];
+      perSystem =
+        {
+          config,
+          pkgs,
+          ...
+        }:
+        let
+          inherit (pkgs)
+            callPackage
+            ;
+          wlroots = callPackage ./nix/wlroots.nix { };
+          cwc = callPackage ./nix/default.nix { inherit wlroots; };
+          shellOverride = old: {
+            nativeBuildInputs = old.nativeBuildInputs ++ [ ];
+            buildInputs = old.buildInputs ++ [ ];
+          };
+        in
+        {
+          packages.default = cwc;
+          overlayAttrs = {
+            inherit (config.packages) cwc;
+          };
+          packages = {
+            inherit cwc;
+          };
+          devShells.default = cwc.overrideAttrs shellOverride;
+          formatter = pkgs.alejandra;
         };
-      in {
-        packages.default = cwc;
-        overlayAttrs = {
-          inherit (config.packages) cwc;
-        };
-        packages = {
-          inherit cwc;
-        };
-        devShells.default = cwc.overrideAttrs shellOverride;
-        formatter = pkgs.alejandra;
-      };
-      systems = ["x86_64-linux"];
+      systems = [ "x86_64-linux" ];
     };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   stdenvAdapters,
   wayland,
-  wlroots_0_19,
   hyprcursor,
   pango,
   cairo,
@@ -30,21 +29,24 @@
   debug ? false,
   gtk3Support ? false,
   gtk3 ? null,
+  wlroots,
 }:
-assert gtk3Support -> gtk3 != null; let
-  inherit (lib.lists) flatten concatLists optional optionals;
-  inherit (builtins) foldl' readFile;
+assert gtk3Support -> gtk3 != null;
+let
+  inherit (lib.lists)
+    flatten
+    ;
+  inherit (builtins) foldl';
 
   luaEnv = luajit.withPackages (ps: [
     ps.lgi
   ]);
-  commonDeps =
-    [
-      gdk-pixbuf
-      pango
-      glib
-    ]
-    ++ lib.optional gtk3Support gtk3;
+  commonDeps = [
+    gdk-pixbuf
+    pango
+    glib
+  ]
+  ++ lib.optional gtk3Support gtk3;
 
   adapters = flatten [
     stdenvAdapters.useMoldLinker
@@ -53,77 +55,86 @@ assert gtk3Support -> gtk3 != null; let
 
   customStdenv = foldl' (acc: adapter: adapter acc) stdenv adapters;
 in
-  customStdenv.mkDerivation {
-    pname = "cwc";
-    version = "nightly";
+customStdenv.mkDerivation {
+  pname = "cwc";
+  version = "nightly";
 
-    src = builtins.path {
-      path = ../.;
-      name = "source";
-    };
+  src = builtins.path {
+    path = ../.;
+    name = "source";
+  };
 
-    nativeBuildInputs = [
-      meson
-      ninja
-      pkg-config
-      wayland-protocols
-      wayland-scanner
-      git
-      python3Minimal
-      makeWrapper
-      wrapGAppsHook3
-      gobject-introspection
-    ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-protocols
+    wayland-scanner
+    git
+    python3Minimal
+    makeWrapper
+    wrapGAppsHook3
+    gobject-introspection
+  ];
 
-    buildInputs =
-      [
-        wayland
-        wlroots_0_19
-        hyprcursor
-        cairo
-        libxkbcommon
-        libinput
-        xxHash
-        xwayland
-        libxcb
-        libxcb-wm
-        luaEnv
-        libdrm
+  buildInputs = [
+    wayland
+    wlroots
+    hyprcursor
+    cairo
+    libxkbcommon
+    libinput
+    xxHash
+    xwayland
+    libxcb
+    libxcb-wm
+    luaEnv
+    libdrm
+  ]
+  ++ commonDeps;
+
+  propagatedBuildInputs = commonDeps;
+
+  doCheck = true;
+
+  GI_TYPELIB_PATH = "${pango.out}/lib/girepository-1.0";
+
+  mesonFlags = [
+    "-Dplugins=true"
+    "-Dtests=false"
+  ];
+
+  LUA_CPATH = "${luaEnv}/lib/lua/${luajit.luaversion}/?.so";
+  LUA_PATH = "${luaEnv}/share/lua/${luajit.luaversion}/?.lua;;";
+
+  postInstall = ''
+    # Copied from @SK4G from #31
+
+    wrapProgram "$out/bin/cwc" \
+    --prefix LUA_PATH : "${luaEnv}/share/lua/5.1/?.lua;${luaEnv}/share/lua/5.1/?/init.lua;${placeholder "out"}/share/cwc/?.lua" \
+    --prefix LUA_CPATH : "${luaEnv}/lib/lua/5.1/?.so;${placeholder "out"}/lib/cwc/plugins/?.so" \
+    --prefix GI_TYPELIB_PATH : "${
+      lib.makeSearchPath "lib/girepository-1.0" [
+        gobject-introspection
+        gtk3
+        pango
+        gdk-pixbuf
       ]
-      ++ commonDeps;
+    }" \
+    --prefix XDG_DATA_DIRS : "$out/share:${gtk3}/share:${gdk-pixbuf}/share:${pango}/share" \
+    --prefix GIO_MODULE_DIR : "${glib}/lib/gio/modules" \
+  '';
 
-    propagatedBuildInputs = commonDeps;
-
-    doCheck = true;
-
-    GI_TYPELIB_PATH = "${pango.out}/lib/girepository-1.0";
-
-    mesonFlags = ["-Dplugins=true" "-Dtests=false"];
-
-    LUA_CPATH = "${luaEnv}/lib/lua/${luajit.luaversion}/?.so";
-    LUA_PATH = "${luaEnv}/share/lua/${luajit.luaversion}/?.lua;;";
-
-    postInstall = ''
-      # Copied from @SK4G from #31
-
-      wrapProgram "$out/bin/cwc" \
-      --prefix LUA_PATH : "${luaEnv}/share/lua/5.1/?.lua;${luaEnv}/share/lua/5.1/?/init.lua;${placeholder "out"}/share/cwc/?.lua" \
-      --prefix LUA_CPATH : "${luaEnv}/lib/lua/5.1/?.so;${placeholder "out"}/lib/cwc/plugins/?.so" \
-      --prefix GI_TYPELIB_PATH : "${lib.makeSearchPath "lib/girepository-1.0" [gobject-introspection gtk3 pango gdk-pixbuf]}" \
-      --prefix XDG_DATA_DIRS : "$out/share:${gtk3}/share:${gdk-pixbuf}/share:${pango}/share" \
-      --prefix GIO_MODULE_DIR : "${glib}/lib/gio/modules" \
-    '';
-
-    passthru = {
-      providedSessions = ["cwc"];
-      inherit luajit;
-    };
-    meta = {
-      mainProgram = "cwc";
-      description = "Hackable wayland compositor";
-      homepage = "https://github.com/Cudiph/cwcwm";
-      license = lib.licenses.gpl3Plus;
-      maintainers = [];
-      platforms = lib.platforms.linux;
-    };
-  }
+  passthru = {
+    providedSessions = [ "cwc" ];
+    inherit luajit;
+  };
+  meta = {
+    mainProgram = "cwc";
+    description = "Hackable wayland compositor";
+    homepage = "https://github.com/Cudiph/cwcwm";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/nix/wlroots.nix
+++ b/nix/wlroots.nix
@@ -1,0 +1,193 @@
+# Originally from https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/development/libraries/wlroots/default.nix
+# At the time of writing this, wlroots_0_20 is not present in nixpkgs (including unstable)
+# MIT License notice:
+# Copyright (c) 2003-2026 Eelco Dolstra and the Nixpkgs/NixOS contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  libGL,
+  wayland,
+  wayland-protocols,
+  libinput,
+  libxkbcommon,
+  pixman,
+  libcap,
+  libgbm,
+  libxcb-wm,
+  libxcb-render-util,
+  libxcb-image,
+  libxcb-errors,
+  libx11,
+  hwdata,
+  seatd,
+  vulkan-loader,
+  glslang,
+  libliftoff,
+  libdisplay-info,
+  lcms2,
+  evdev-proto,
+  nixosTests,
+  testers,
+
+  enableXWayland ? true,
+  xwayland ? null,
+}:
+
+let
+  generic =
+    {
+      version,
+      hash,
+      extraBuildInputs ? [ ],
+      extraNativeBuildInputs ? [ ],
+      patches ? [ ],
+      postPatch ? "",
+    }:
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "wlroots";
+      inherit version;
+
+      inherit enableXWayland;
+
+      src = fetchFromGitLab {
+        domain = "gitlab.freedesktop.org";
+        owner = "wlroots";
+        repo = "wlroots";
+        rev = finalAttrs.version;
+        inherit hash;
+      };
+
+      inherit patches postPatch;
+
+      # $out for the library and $examples for the example programs (in examples):
+      outputs = [
+        "out"
+        "examples"
+      ];
+
+      strictDeps = true;
+      depsBuildBuild = [ pkg-config ];
+
+      nativeBuildInputs = [
+        meson
+        ninja
+        pkg-config
+        wayland-scanner
+        glslang
+        hwdata
+      ]
+      ++ extraNativeBuildInputs;
+
+      propagatedBuildInputs = [
+        # The headers of wlroots #include <libinput.h>, and consumers of `wlroots` need not add it explicitly, hence we propagate it.
+        libinput
+      ];
+
+      buildInputs = [
+        libliftoff
+        libdisplay-info
+        libGL
+        libxkbcommon
+        libgbm
+        pixman
+        seatd
+        vulkan-loader
+        wayland
+        wayland-protocols
+        libx11
+        libxcb-errors
+        libxcb-image
+        libxcb-render-util
+        libxcb-wm
+      ]
+      ++ lib.optional stdenv.hostPlatform.isLinux libcap
+      ++ lib.optional stdenv.hostPlatform.isFreeBSD evdev-proto
+      ++ lib.optional finalAttrs.enableXWayland xwayland
+      ++ extraBuildInputs;
+
+      mesonFlags = [
+        (lib.mesonEnable "xwayland" finalAttrs.enableXWayland)
+      ]
+      # The other allocator, udmabuf, is a linux-specific API
+      ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
+        (lib.mesonOption "allocators" "gbm")
+      ];
+
+      postFixup = ''
+        # Install ALL example programs to $examples:
+        # screencopy dmabuf-capture input-inhibitor layer-shell idle-inhibit idle
+        # screenshot output-layout multi-pointer rotation tablet touch pointer
+        # simple
+        mkdir -p $examples/bin
+        cd ./examples
+        for binary in $(find . -executable -type f -printf '%P\n' | grep -vE '\.so'); do
+          cp "$binary" "$examples/bin/wlroots-$binary"
+        done
+      '';
+
+      # Test via TinyWL (the "minimum viable product" Wayland compositor based on wlroots):
+      passthru.tests = {
+        tinywl = nixosTests.tinywl;
+        pkg-config = testers.hasPkgConfigModules {
+          package = finalAttrs.finalPackage;
+        };
+      };
+
+      meta = {
+        description = "Modular Wayland compositor library";
+        longDescription = ''
+          Pluggable, composable, unopinionated modules for building a Wayland
+          compositor; or about 50,000 lines of code you were going to write anyway.
+        '';
+        inherit (finalAttrs.src.meta) homepage;
+        changelog = "https://gitlab.freedesktop.org/wlroots/wlroots/-/tags/${version}";
+        license = lib.licenses.mit;
+        platforms = lib.platforms.linux ++ lib.platforms.freebsd;
+        maintainers = with lib.maintainers; [
+          synthetica
+          wineee
+          doronbehar
+        ];
+        pkgConfigModules = [
+          (
+            if lib.versionOlder finalAttrs.version "0.18" then
+              "wlroots"
+            else
+              "wlroots-${lib.versions.majorMinor finalAttrs.version}"
+          )
+        ];
+      };
+    });
+
+in
+generic {
+  version = "0.20.0-rc4";
+  hash = "sha256-LIS6FqWfkq36f62RYlkD5138mP/ZSTTOhw+ToPK5lzY=";
+  extraBuildInputs = [
+    lcms2
+  ];
+}


### PR DESCRIPTION
Currently, the project takes in 0.19 version as input, but building it requires 0.20. This pull request fixes this, but there's two main changes which may break stuff:
1. [nixpkgs doesn't have 0.20 version yet](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/development/libraries/wlroots/default.nix). To fix this, I copied over the `wlroots/default.nix` file over (it's under MIT license unless I misunderstood), changed the target branch, and added that in the build process. I added an attribute and a copy of the notice at the top. I hope that's how you comply...
2. The current nixpkgs locked by `flake.lock` file does not have the latest version of `libdrm`, which is required for building `wlroots` 0.20. I had to update the flake as a result.

Building `cwcwm` works immediately from `git clone` - `nix develop` - `make` now, and adding it as input for my system works.